### PR TITLE
Weighted modularity wrapper accepts SciPy sparse matrices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.pyc
+*.o
+external/SurpriseMeCPM/*/
+.ropeproject/
+*.egg-info/
+*.egg/


### PR DESCRIPTION
This adds support for scipy sparse matrices into `graphy.louvain.optimize_modularity`. The connection matrix (`connmx`) is converted to list-of-lists sparse format and then dumped into the Pajek format required by the C++ implementation.

Also added a few git ignore patterns (.pyc and .o object files).  